### PR TITLE
fix: result overview에 나오는 수치 수정

### DIFF
--- a/frontend/src/pages/TrainingPage.tsx
+++ b/frontend/src/pages/TrainingPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '../state/trackingSessionContext';
 import { useAuth } from '../state/authContext';
 import { serializeSessionToCsv } from '../utils/sessionExport';
+import { calculatePerformanceAnalytics } from '../utils/analytics';
 
 const TrainingPage = () => {
   const navigate = useNavigate();
@@ -53,35 +54,9 @@ const TrainingPage = () => {
     }));
   };
 
-  // Calculate metrics from raw data
-  const calculateMetrics = (rawData: TrackingDataRecord[], targetsHit: number) => {
-    const hitRecords = rawData.filter(d => d.hitRegistered);
-    const totalTargets = hitRecords.length;
-    const accuracy = totalTargets > 0 ? (targetsHit / totalTargets) * 100 : 0;
-
-    // Calculate average reaction time (simplified)
-    // This would need proper implementation based on your game mechanics
-    const avgReactionTime = 250; // Placeholder
-
-    // Calculate gaze and mouse accuracy (simplified)
-    const gazeRecords = rawData.filter(d => d.gazeX !== null && d.gazeY !== null);
-    const mouseRecords = rawData.filter(d => d.mouseX !== null && d.mouseY !== null);
-    
-    const gazeAccuracy = gazeRecords.length > 0 ? 75 : 0; // Placeholder
-    const mouseAccuracy = mouseRecords.length > 0 ? 85 : 0; // Placeholder
-
-    return {
-      accuracy,
-      avgReactionTime,
-      gazeAccuracy,
-      mouseAccuracy,
-      totalTargets,
-    };
-  };
-
   const handleTrainingComplete = useCallback((
-    score: number, 
-    targetsHit: number, 
+    score: number,
+    targetsHit: number,
     rawTrackingData: TrackingDataRecord[]
   ) => {
     setIsComplete(true);
@@ -96,9 +71,9 @@ const TrainingPage = () => {
 
     // Convert the raw tracking data to the format expected by the session system
     const convertedData = convertTrainingData(rawTrackingData);
-    
+
     // Calculate metrics from the collected data
-    const metrics = calculateMetrics(rawTrackingData, targetsHit);
+    const metrics = calculatePerformanceAnalytics(convertedData);
     
     // Create the session record with actual data
     const sessionRecord: TrainingSessionSummary = {
@@ -107,7 +82,7 @@ const TrainingPage = () => {
       duration: 60,
       score: score,
       accuracy: metrics.accuracy,
-      targetsHit: targetsHit,
+      targetsHit: metrics.targetsHit,
       totalTargets: metrics.totalTargets,
       avgReactionTime: metrics.avgReactionTime,
       gazeAccuracy: metrics.gazeAccuracy,

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -1,0 +1,70 @@
+import { TrainingDataPoint } from '../state/trackingSessionContext';
+
+export interface PerformanceAnalytics {
+  totalTargets: number;
+  targetsHit: number;
+  accuracy: number;
+  avgReactionTime: number;
+  gazeAccuracy: number;
+  mouseAccuracy: number;
+}
+
+export const calculatePerformanceAnalytics = (data: TrainingDataPoint[]): PerformanceAnalytics => {
+  if (data.length === 0) {
+    return {
+      totalTargets: 0,
+      targetsHit: 0,
+      accuracy: 0,
+      avgReactionTime: 0,
+      gazeAccuracy: 0,
+      mouseAccuracy: 0,
+    };
+  }
+
+  const hits = data.filter(d => d.targetHit);
+  const targetIds = new Set<string>();
+  const firstSeenByTarget = new Map<string, number>();
+
+  data.forEach(point => {
+    if (!point.targetId) return;
+
+    targetIds.add(point.targetId);
+    const existing = firstSeenByTarget.get(point.targetId);
+    if (existing === undefined || point.timestamp < existing) {
+      firstSeenByTarget.set(point.targetId, point.timestamp);
+    }
+  });
+
+  const reactionTimes = hits
+    .map(hit => {
+      if (!hit.targetId) return null;
+      const firstSeen = firstSeenByTarget.get(hit.targetId);
+      if (firstSeen === undefined) return null;
+
+      return hit.timestamp - firstSeen;
+    })
+    .filter((value): value is number => value !== null && isFinite(value) && value >= 0);
+
+  const avgReactionTime = reactionTimes.length > 0
+    ? reactionTimes.reduce((a, b) => a + b, 0) / reactionTimes.length
+    : 0;
+
+  const dataWithGaze = data.filter(d => d.gazeX !== null && d.gazeY !== null);
+  const dataWithMouse = data.filter(d => d.mouseX !== null && d.mouseY !== null);
+
+  const totalTargets = targetIds.size || hits.length;
+  const targetsHit = hits.length;
+
+  const accuracy = totalTargets > 0 ? (targetsHit / totalTargets) * 100 : 0;
+  const gazeAccuracy = (dataWithGaze.length / data.length) * 100;
+  const mouseAccuracy = (dataWithMouse.length / data.length) * 100;
+
+  return {
+    totalTargets,
+    targetsHit,
+    accuracy,
+    avgReactionTime,
+    gazeAccuracy,
+    mouseAccuracy,
+  };
+};


### PR DESCRIPTION
- Added a shared performance analytics utility that derives target counts, accuracy, reaction times, and data completeness directly from recorded training points.

- Updated training session completion to use the shared analytics, ensuring saved session metrics reflect the recorded tracking data.

- Reused the centralized analytics on the results page so the performance overview displays consistent, accurate metrics from the session data