### PR TITLE
fix: 최근 8개 기록에서 최근 타겟으로 변경 및 리플레이 베타버전

### DIFF
--- a/frontend/src/pages/DetailedResultsPage.css
+++ b/frontend/src/pages/DetailedResultsPage.css
@@ -346,6 +346,28 @@
   padding: 0.75rem 1rem;
 }
 
+.replay-legend {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  color: #d8ddf3;
+  font-weight: 600;
+}
+
+.legend-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  margin-right: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+}
+
+.legend-dot.target { background: rgba(255, 99, 132, 0.8); }
+.legend-dot.mouse { background: #ffb86c; }
+.legend-dot.gaze { background: #4ecdc4; }
+
 .replay-progress {
   width: 100%;
   height: 10px;
@@ -353,6 +375,7 @@
   border-radius: 999px;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.12);
+  position: relative;
 }
 
 .replay-progress > div {
@@ -361,10 +384,56 @@
   transition: width 120ms linear;
 }
 
+.replay-progress input[type="range"] {
+  position: absolute;
+  inset: -8px 0 -8px 0;
+  width: 100%;
+  background: transparent;
+  -webkit-appearance: none;
+}
+
+.replay-progress input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #6dd5ed;
+  border: 2px solid #1c3b4d;
+  cursor: pointer;
+}
+
+.replay-progress input[type="range"]::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #6dd5ed;
+  border: 2px solid #1c3b4d;
+  cursor: pointer;
+}
+
 .replay-controls {
   display: flex;
   gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
 }
+
+.replay-speed {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #d8ddf3;
+  font-weight: 600;
+}
+
+.replay-speed select {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: #f7f7ff;
+  border-radius: 8px;
+  padding: 0.35rem 0.5rem;
+}
+
 
 @media (max-width: 900px) {
   .detailed-results-page {

--- a/frontend/src/pages/DetailedResultsPage.tsx
+++ b/frontend/src/pages/DetailedResultsPage.tsx
@@ -317,6 +317,7 @@ const DetailedResultsPage = () => {
   const [replaySamples, setReplaySamples] = useState<TrainingDataPoint[]>([]);
   const [replayIndex, setReplayIndex] = useState(0);
   const [isReplaying, setIsReplaying] = useState(false);
+  const [replaySpeed, setReplaySpeed] = useState(0.2);
 
   // --- NEW: Metric Visibility State ---
   const [visibleMetrics, setVisibleMetrics] = useState<Record<string, boolean>>({
@@ -819,15 +820,14 @@ const DetailedResultsPage = () => {
 
     const current = replaySamples[currentIndex];
     const next = replaySamples[currentIndex + 1];
-    const slowdown = 3;
-    const delay = Math.max(90, (next.timestamp - current.timestamp) / slowdown);
+    const delay = Math.max(120, (next.timestamp - current.timestamp) / replaySpeed);
 
     const timeout = window.setTimeout(() => {
       setReplayIndex(idx => Math.min(idx + 1, replaySamples.length - 1));
     }, delay);
 
     return () => window.clearTimeout(timeout);
-  }, [isReplaying, replayIndex, replaySamples]);
+  }, [isReplaying, replayIndex, replaySamples, replaySpeed]);
 
   const closeReplay = useCallback(() => {
     setIsReplaying(false);
@@ -888,6 +888,19 @@ const DetailedResultsPage = () => {
   const replayStartTime = replaySamples[0]?.timestamp ?? 0;
   const replayDurationMs = (replaySamples.at(-1)?.timestamp ?? replayStartTime) - replayStartTime;
   const replayElapsedMs = currentReplayFrame ? currentReplayFrame.timestamp - replayStartTime : 0;
+  const replayProgressPct = replayDurationMs > 0 ? Math.min(100, Math.max(0, (replayElapsedMs / replayDurationMs) * 100)) : 0;
+
+  const scrubToProgress = (percent: number) => {
+    if (!replaySamples.length || replayDurationMs <= 0) return;
+    const clamped = Math.min(100, Math.max(0, percent));
+    const targetTime = replayStartTime + (clamped / 100) * replayDurationMs;
+    const nextIndex = replaySamples.findIndex(p => p.timestamp >= targetTime);
+    if (nextIndex === -1) {
+      setReplayIndex(replaySamples.length - 1);
+    } else {
+      setReplayIndex(nextIndex);
+    }
+  };
 
   const projectReplayPoint = useCallback((value: number | null, isX: boolean, size: number) => {
     const min = isX ? replayBounds.minX : replayBounds.minY;
@@ -1277,11 +1290,11 @@ const DetailedResultsPage = () => {
         </div>
       </section>
 
-      {/* Recent Samples 섹션 */}
+      {/* Session Targets 섹션 */}
       <section className="detail-section">
         <div className="section-header">
-          <h2>Recent Samples</h2>
-          <p className="muted">최근 타겟의 오차와 반응 시간을 확인하세요. 한 번에 8개씩 표시되며 스크롤로 이전 타겟까지 탐색할 수 있습니다. 타겟 ID를 누르면 해당 타겟 등장부터 사라질 때까지의 슬로우모션 리플레이가 재생됩니다.</p>
+          <h2>Recent Targets</h2>
+          <p className="muted">세션동안 등장한 타겟의 오차와 반응 시간을 확인하세요. 한 번에 8개씩 표시되며 스크롤로 다음 타겟까지 탐색할 수 있습니다. 타겟 ID를 누르면 해당 타겟 등장부터 사라질 때까지의 슬로우모션 리플레이가 재생됩니다.</p>
         </div>
         <div className="samples-table scrollable">
           <div className="samples-scroll">
@@ -1327,7 +1340,7 @@ const DetailedResultsPage = () => {
                 <p className="card-label">Target Replay</p>
                 <h3 className="replay-title">#{replayTargetId}</h3>
                 <p className="muted">
-                  등장부터 사라질 때까지를 {currentReplayFrame?.targetHit ? '명중 프레임 포함' : '마지막 프레임까지'} 0.3× 속도로 재생합니다.
+                  등장부터 사라질 때까지를 {currentReplayFrame?.targetHit ? '명중 프레임 포함' : '마지막 프레임까지'} 느린 속도로 재생합니다. 배속을 선택하거나, 재생바를 움직여 원하는 구간을 바로 확인할 수 있습니다.
                 </p>
               </div>
               <button type="button" className="detail-button ghost" onClick={closeReplay}>Close</button>
@@ -1391,6 +1404,11 @@ const DetailedResultsPage = () => {
                 </svg>
               </div>
               <div className="replay-meta">
+                <div className="replay-legend" aria-label="점 설명">
+                  <span><span className="legend-dot target" /> Target</span>
+                  <span><span className="legend-dot mouse" /> Mouse</span>
+                  <span><span className="legend-dot gaze" /> Gaze</span>
+                </div>
                 <div className="stat-row">
                   <span>Time window</span>
                   <strong>{(replayDurationMs / 1000).toFixed(2)} s</strong>
@@ -1404,9 +1422,30 @@ const DetailedResultsPage = () => {
                   <strong>{currentReplayFrame?.targetHit ? 'Hit' : 'Tracking'}</strong>
                 </div>
                 <div className="replay-progress" aria-label="replay progress">
-                  <div style={{ width: `${replayDurationMs > 0 ? Math.min(100, (replayElapsedMs / replayDurationMs) * 100) : 0}%` }} />
+                  <div style={{ width: `${replayProgressPct}%` }} />
+                  <input
+                    type="range"
+                    min={0}
+                    max={100}
+                    step={0.1}
+                    value={replayProgressPct}
+                    onChange={e => scrubToProgress(Number(e.target.value))}
+                    aria-label="재생 위치 조절"
+                  />
                 </div>
                 <div className="replay-controls">
+                  <label className="replay-speed" htmlFor="replay-speed-select">
+                    Speed
+                    <select
+                      id="replay-speed-select"
+                      value={replaySpeed}
+                      onChange={e => setReplaySpeed(Number(e.target.value))}
+                    >
+                      {[0.1, 0.2, 0.3, 0.5, 1].map(speed => (
+                        <option key={speed} value={speed}>{`${speed.toFixed(1)}×`}</option>
+                      ))}
+                    </select>
+                  </label>
                   <button
                     type="button"
                     className="detail-button small"


### PR DESCRIPTION
recent samples 표의 항목을 최근 8개 timestamp에서 전체 세션 동안의 타겟에 대한 정보로 바꿈