### PR TITLE
feat: 사용자가 직접 세션 기록 삭제 기능

### DIFF
--- a/frontend/src/constants/translations.ts
+++ b/frontend/src/constants/translations.ts
@@ -763,6 +763,17 @@ export const translations: Record<string, Record<Language, string>> = {
   'sessions.table.view': { ko: '보기', en: 'View' },
   'sessions.table.report.create': { ko: '리포트 생성하기', en: 'Create Report' },
   'sessions.table.report.viewExisting': { ko: '리포트 확인하기', en: 'View Report' },
+  'sessions.table.delete': { ko: '삭제', en: 'Delete' },
+  'sessions.table.deleting': { ko: '삭제 중...', en: 'Deleting...' },
+  'sessions.delete.confirm': {
+    ko: '이 세션을 기록에서 삭제할까요? 이 작업은 되돌릴 수 없습니다.',
+    en: 'Delete this session from your history? This action cannot be undone.',
+  },
+  'sessions.delete.success': { ko: '세션이 기록에서 삭제되었습니다.', en: 'Session removed from your history.' },
+  'sessions.delete.error': {
+    ko: '세션을 삭제하지 못했습니다. 다시 시도해주세요.',
+    en: 'Failed to delete the session. Please try again.',
+  },
   'sessions.empty.title': { ko: '아직 세션이 없습니다', en: 'No sessions yet' },
   'sessions.empty.desc': { ko: '트레이닝을 시작해 여기에서 세션 기록을 확인하세요', en: 'Start training to see your session history here' },
   'sessions.empty.cta': { ko: '트레이닝 시작', en: 'Start Training' },
@@ -1176,6 +1187,12 @@ export const translations: Record<string, Record<Language, string>> = {
   'results.data.uploading': { ko: '업로드 중…', en: 'Uploading…' },
   'results.data.retryUpload': { ko: '업로드 재시도', en: 'Retry Upload' },
   'results.data.upload': { ko: 'Firebase Storage에 업로드', en: 'Upload to Firebase Storage' },
+  'results.data.delete': { ko: '세션 삭제', en: 'Delete Session' },
+  'results.data.deleting': { ko: '삭제 중…', en: 'Deleting…' },
+  'results.delete.confirm': {
+    ko: '이 세션 데이터를 완전히 삭제할까요? 삭제하면 되돌릴 수 없습니다.',
+    en: 'Delete this session data permanently? This cannot be undone.',
+  },
   'results.action.trainAgain': { ko: '다시 트레이닝', en: 'Train Again' },
   'results.action.backDashboard': { ko: '대시보드로 돌아가기', en: 'Back to Dashboard' },
   'results.finish.prompt': {
@@ -1195,6 +1212,11 @@ export const translations: Record<string, Record<Language, string>> = {
   'results.toast.downloadSuccess': { ko: 'CSV 다운로드 완료.', en: 'CSV downloaded successfully.' },
   'results.toast.uploadFailed': { ko: 'CSV 업로드 실패: {message}', en: 'CSV upload failed: {message}' },
   'results.toast.exportFailed': { ko: 'CSV 내보내기 실패: {message}', en: 'CSV export failed: {message}' },
+  'results.toast.deleteSuccess': { ko: '세션 데이터가 삭제되었습니다.', en: 'Session data deleted.' },
+  'results.toast.deleteError': {
+    ko: '세션을 삭제하지 못했습니다. 잠시 후 다시 시도해주세요.',
+    en: 'Failed to delete the session. Please try again shortly.',
+  },
   'results.tooltip.targets': { ko: '명중 수는 결정력과 전투 페이스를 보여줍니다.', en: 'Hits show decisiveness and tempo.' },
   'results.tooltip.avgReaction': { ko: '반응 시간이 짧을수록 첫 발 이점을 가져갑니다.', en: 'Faster reactions secure the first-shot edge.' },
   'results.tooltip.gazeReaction': { ko: '시선 반응은 목표 포착 속도를 의미합니다.', en: 'Gaze reaction shows how fast you acquire targets.' },

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -168,7 +168,7 @@ const DashboardPage = () => {
     return best;
   }, [recentSessions]);
 
-  const percentileColor = (percentile: number) => (percentile <= 25 ? '#66d9ff' : percentile <= 60 ? '#f1c40f' : '#ff6b6b');
+  const percentileColor = (percentile: number) => (percentile <= 35 ? '#66d9ff' : percentile <= 70 ? '#f1c40f' : '#ff6b6b');
 
   const formatPercentileLabel = (percentile: number) => {
     const template = t(
@@ -189,27 +189,23 @@ const DashboardPage = () => {
   const reactionPercentile = useMemo(() => {
     if (!bestReactionSession) return null;
     const buckets = [
-      { max: 300, percentile: 8 },
-      { max: 400, percentile: 14 },
-      { max: 500, percentile: 18 },
-      { max: 600, percentile: 24 },
-      { max: 700, percentile: 28 },
-      { max: 800, percentile: 32 },
-      { max: 900, percentile: 40 },
+      { max: 300, percentile: 10 },
+      { max: 450, percentile: 18 },
+      { max: 650, percentile: 26 },
+      { max: 820, percentile: 30 },
       { max: 1100, percentile: 55 },
-      { max: 1400, percentile: 70 },
     ];
-    return mapToPercentile(bestReactionSession.avgReactionTime, buckets, 90);
+    return mapToPercentile(bestReactionSession.avgReactionTime, buckets, 85);
   }, [bestReactionSession, language, t]);
 
   const gazePercentile = useMemo(() => {
     if (!bestGazeReaction) return null;
     const buckets = [
-      { max: 180, percentile: 10 },
-      { max: 220, percentile: 22 },
-      { max: 270, percentile: 40 },
-      { max: 330, percentile: 58 },
-      { max: 400, percentile: 72 },
+      { max: 200, percentile: 10 },
+      { max: 280, percentile: 20 },
+      { max: 340, percentile: 35 },
+      { max: 420, percentile: 50 },
+      { max: 520, percentile: 72 },
     ];
     return mapToPercentile(bestGazeReaction.gaze, buckets, 90);
   }, [bestGazeReaction, language, t]);
@@ -217,14 +213,13 @@ const DashboardPage = () => {
   const gazeAimPercentile = useMemo(() => {
     if (!bestGazeAimLatency) return null;
     const buckets = [
-      { max: 220, percentile: 10 },
-      { max: 300, percentile: 20 },
-      { max: 380, percentile: 38 },
-      { max: 480, percentile: 55 },
-      { max: 600, percentile: 72 },
-      { max: 720, percentile: 88 },
+      { max: 320, percentile: 18 },
+      { max: 480, percentile: 35 },
+      { max: 650, percentile: 45 },
+      { max: 780, percentile: 50 },
+      { max: 950, percentile: 70 },
     ];
-    return mapToPercentile(bestGazeAimLatency.latency, buckets, 96);
+    return mapToPercentile(bestGazeAimLatency.latency, buckets, 90);
   }, [bestGazeAimLatency, language, t]);
 
   const sgRankSinceText = useMemo(() => {

--- a/frontend/src/pages/DetailedResultsPage.tsx
+++ b/frontend/src/pages/DetailedResultsPage.tsx
@@ -158,41 +158,46 @@ const metricPercentile = (
   switch (key) {
     case 'accuracy': {
       const ratio = analytics.totalTargets > 0 ? analytics.targetsHit / analytics.totalTargets : 0;
-      if (ratio >= 0.9) return { value: 10, label: formatPercentileLabel(10, formatter) };
-      if (ratio >= 0.8) return { value: 20, label: formatPercentileLabel(20, formatter) };
-      if (ratio >= 0.65) return { value: 40, label: formatPercentileLabel(40, formatter) };
-      if (ratio >= 0.5) return { value: 60, label: formatPercentileLabel(60, formatter) };
+      if (ratio >= 0.95) return { value: 12, label: formatPercentileLabel(12, formatter) };
+      if (ratio >= 0.85) return { value: 28, label: formatPercentileLabel(28, formatter) };
+      if (ratio >= 0.7) return { value: 45, label: formatPercentileLabel(45, formatter) };
+      if (ratio >= 0.55) return { value: 65, label: formatPercentileLabel(65, formatter) };
       return { value: 85, label: formatPercentileLabel(85, formatter) };
     }
     case 'reaction': {
       const v = analytics.avgReactionTime;
-      if (v <= 200) return { value: 10, label: formatPercentileLabel(10, formatter) };
-      if (v <= 250) return { value: 25, label: formatPercentileLabel(25, formatter) };
-      if (v <= 300) return { value: 50, label: formatPercentileLabel(50, formatter) };
-      if (v <= 350) return { value: 70, label: formatPercentileLabel(70, formatter) };
-      return { value: 90, label: formatPercentileLabel(90, formatter) };
+      if (v <= 300) return { value: 10, label: formatPercentileLabel(10, formatter) };
+      if (v <= 450) return { value: 18, label: formatPercentileLabel(18, formatter) };
+      if (v <= 650) return { value: 26, label: formatPercentileLabel(26, formatter) };
+      if (v <= 820) return { value: 30, label: formatPercentileLabel(30, formatter) };
+      if (v <= 1100) return { value: 55, label: formatPercentileLabel(55, formatter) };
+      return { value: 85, label: formatPercentileLabel(85, formatter) };
     }
     case 'gaze': {
       const v = analytics.avgGazeReactionTime;
-      if (v <= 200) return { value: 12, label: formatPercentileLabel(12, formatter) };
-      if (v <= 250) return { value: 25, label: formatPercentileLabel(25, formatter) };
-      if (v <= 350) return { value: 45, label: formatPercentileLabel(45, formatter) };
-      if (v <= 450) return { value: 65, label: formatPercentileLabel(65, formatter) };
-      return { value: 88, label: formatPercentileLabel(88, formatter) };
+      if (v <= 200) return { value: 10, label: formatPercentileLabel(10, formatter) };
+      if (v <= 280) return { value: 20, label: formatPercentileLabel(20, formatter) };
+      if (v <= 340) return { value: 35, label: formatPercentileLabel(35, formatter) };
+      if (v <= 420) return { value: 50, label: formatPercentileLabel(50, formatter) };
+      if (v <= 520) return { value: 72, label: formatPercentileLabel(72, formatter) };
+      return { value: 90, label: formatPercentileLabel(90, formatter) };
     }
     case 'gazeAim': {
       const v = analytics.gazeAimLatency;
-      if (v <= 250) return { value: 15, label: formatPercentileLabel(15, formatter) };
-      if (v <= 400) return { value: 35, label: formatPercentileLabel(35, formatter) };
-      if (v <= 600) return { value: 60, label: formatPercentileLabel(60, formatter) };
-      return { value: 85, label: formatPercentileLabel(85, formatter) };
+      if (v <= 320) return { value: 18, label: formatPercentileLabel(18, formatter) };
+      if (v <= 480) return { value: 35, label: formatPercentileLabel(35, formatter) };
+      if (v <= 650) return { value: 45, label: formatPercentileLabel(45, formatter) };
+      if (v <= 780) return { value: 50, label: formatPercentileLabel(50, formatter) };
+      if (v <= 950) return { value: 70, label: formatPercentileLabel(70, formatter) };
+      return { value: 90, label: formatPercentileLabel(90, formatter) };
     }
     case 'sync': {
       const v = analytics.synchronization;
-      if (v <= 90) return { value: 15, label: formatPercentileLabel(15, formatter) };
-      if (v <= 140) return { value: 35, label: formatPercentileLabel(35, formatter) };
-      if (v <= 200) return { value: 60, label: formatPercentileLabel(60, formatter) };
-      return { value: 85, label: formatPercentileLabel(85, formatter) };
+      if (v <= 110) return { value: 18, label: formatPercentileLabel(18, formatter) };
+      if (v <= 150) return { value: 30, label: formatPercentileLabel(30, formatter) };
+      if (v <= 190) return { value: 40, label: formatPercentileLabel(40, formatter) };
+      if (v <= 230) return { value: 60, label: formatPercentileLabel(60, formatter) };
+      return { value: 80, label: formatPercentileLabel(80, formatter) };
     }
     case 'coverage': {
       const gazeCov = coverage?.gaze ?? 0;
@@ -619,31 +624,31 @@ const DetailedResultsPage = () => {
         case 'accuracy': {
           const ratio = analytics.totalTargets > 0 ? analytics.targetsHit / analytics.totalTargets : 0;
           if (ratio >= 0.8) return { label: t('results.level.targets.top', 'High hit rate'), color: goodColor };
-          if (ratio >= 0.5) return { label: t('results.level.targets.mid', 'Average hit rate'), color: midColor };
+          if (ratio >= 0.7) return { label: t('results.level.targets.mid', 'Average hit rate'), color: midColor };
           return { label: t('results.level.targets.low', 'Needs hit rate improvement'), color: badColor };
         }
         case 'reaction': {
           const v = analytics.avgReactionTime;
-          if (v <= 300) return { label: t('results.level.reaction.top', 'Excellent reaction time'), color: goodColor };
-          if (v <= 600) return { label: t('results.level.reaction.mid', 'Average reaction time'), color: midColor };
+          if (v <= 450) return { label: t('results.level.reaction.top', 'Excellent reaction time'), color: goodColor };
+          if (v <= 900) return { label: t('results.level.reaction.mid', 'Average reaction time'), color: midColor };
           return { label: t('results.level.reaction.low', 'Needs reaction improvement'), color: badColor };
         }
         case 'gaze': {
           const v = analytics.avgGazeReactionTime;
-          if (v <= 250) return { label: t('results.level.gaze.top', 'Fast gaze acquisition'), color: goodColor };
-          if (v <= 450) return { label: t('results.level.gaze.mid', 'Average gaze acquisition'), color: midColor };
+          if (v <= 320) return { label: t('results.level.gaze.top', 'Fast gaze acquisition'), color: goodColor };
+          if (v <= 520) return { label: t('results.level.gaze.mid', 'Average gaze acquisition'), color: midColor };
           return { label: t('results.level.gaze.low', 'Slow gaze acquisition'), color: badColor };
         }
         case 'gazeAim': {
           const v = analytics.gazeAimLatency;
-          if (v <= 300) return { label: t('results.level.gazeAim.top', 'Short gaze-hand delay'), color: goodColor };
-          if (v <= 600) return { label: t('results.level.gazeAim.mid', 'Average gaze-hand delay'), color: midColor };
+          if (v <= 480) return { label: t('results.level.gazeAim.top', 'Short gaze-hand delay'), color: goodColor };
+          if (v <= 900) return { label: t('results.level.gazeAim.mid', 'Average gaze-hand delay'), color: midColor };
           return { label: t('results.level.gazeAim.low', 'Needs latency improvement'), color: badColor };
         }
         case 'sync': {
           const v = analytics.synchronization;
-          if (v <= 120) return { label: t('results.level.sync.top', 'Great gaze-mouse sync'), color: goodColor };
-          if (v <= 200) return { label: t('results.level.sync.mid', 'Average sync'), color: midColor };
+          if (v <= 150) return { label: t('results.level.sync.top', 'Great gaze-mouse sync'), color: goodColor };
+          if (v <= 230) return { label: t('results.level.sync.mid', 'Average sync'), color: midColor };
           return { label: t('results.level.sync.low', 'Needs sync improvement'), color: badColor };
         }
         case 'coverage': {

--- a/frontend/src/pages/ReportPage.css
+++ b/frontend/src/pages/ReportPage.css
@@ -522,8 +522,8 @@
 
 .data-percentile {
   font-size: 0.9rem;
-  color: #7c9bff;
-  font-weight: 600;
+  color: inherit;
+  font-weight: 700;
 }
 
 /* New Report Button */

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -29,54 +29,59 @@ const formatPercentileLabel = (value: number, formatter: (pct: number) => string
 const metricPercentile = (
   key: MetricKey,
   analytics: PerformanceAnalytics,
-  formatter: (pct: number) => string,
+    formatter: (pct: number) => string,
 ): MetricPercentile => {
   switch (key) {
     case 'targets': {
       const ratio = analytics.totalTargets > 0 ? analytics.targetsHit / analytics.totalTargets : 0;
-      if (ratio >= 0.9) return { value: 10, label: formatPercentileLabel(10, formatter) };
-      if (ratio >= 0.8) return { value: 20, label: formatPercentileLabel(20, formatter) };
-      if (ratio >= 0.65) return { value: 40, label: formatPercentileLabel(40, formatter) };
-      if (ratio >= 0.5) return { value: 60, label: formatPercentileLabel(60, formatter) };
+      if (ratio >= 0.95) return { value: 12, label: formatPercentileLabel(12, formatter) };
+      if (ratio >= 0.85) return { value: 28, label: formatPercentileLabel(28, formatter) };
+      if (ratio >= 0.7) return { value: 45, label: formatPercentileLabel(45, formatter) };
+      if (ratio >= 0.55) return { value: 65, label: formatPercentileLabel(65, formatter) };
       return { value: 85, label: formatPercentileLabel(85, formatter) };
     }
     case 'avgReaction': {
       const v = analytics.avgReactionTime;
-      if (v <= 200) return { value: 10, label: formatPercentileLabel(10, formatter) };
-      if (v <= 250) return { value: 25, label: formatPercentileLabel(25, formatter) };
-      if (v <= 300) return { value: 50, label: formatPercentileLabel(50, formatter) };
-      if (v <= 350) return { value: 70, label: formatPercentileLabel(70, formatter) };
-      return { value: 90, label: formatPercentileLabel(90, formatter) };
+      if (v <= 300) return { value: 10, label: formatPercentileLabel(10, formatter) };
+      if (v <= 450) return { value: 18, label: formatPercentileLabel(18, formatter) };
+      if (v <= 650) return { value: 26, label: formatPercentileLabel(26, formatter) };
+      if (v <= 820) return { value: 30, label: formatPercentileLabel(30, formatter) };
+      if (v <= 1100) return { value: 55, label: formatPercentileLabel(55, formatter) };
+      return { value: 85, label: formatPercentileLabel(85, formatter) };
     }
     case 'gazeReaction': {
       const v = analytics.avgGazeReactionTime;
-      if (v <= 200) return { value: 12, label: formatPercentileLabel(12, formatter) };
-      if (v <= 250) return { value: 25, label: formatPercentileLabel(25, formatter) };
-      if (v <= 350) return { value: 45, label: formatPercentileLabel(45, formatter) };
-      if (v <= 450) return { value: 65, label: formatPercentileLabel(65, formatter) };
-      return { value: 88, label: formatPercentileLabel(88, formatter) };
+      if (v <= 200) return { value: 10, label: formatPercentileLabel(10, formatter) };
+      if (v <= 280) return { value: 20, label: formatPercentileLabel(20, formatter) };
+      if (v <= 340) return { value: 35, label: formatPercentileLabel(35, formatter) };
+      if (v <= 420) return { value: 50, label: formatPercentileLabel(50, formatter) };
+      if (v <= 520) return { value: 72, label: formatPercentileLabel(72, formatter) };
+      return { value: 90, label: formatPercentileLabel(90, formatter) };
     }
     case 'gazeAimLatency': {
       const v = analytics.gazeAimLatency;
-      if (v <= 250) return { value: 15, label: formatPercentileLabel(15, formatter) };
-      if (v <= 400) return { value: 35, label: formatPercentileLabel(35, formatter) };
-      if (v <= 600) return { value: 60, label: formatPercentileLabel(60, formatter) };
-      return { value: 85, label: formatPercentileLabel(85, formatter) };
+      if (v <= 320) return { value: 18, label: formatPercentileLabel(18, formatter) };
+      if (v <= 480) return { value: 35, label: formatPercentileLabel(35, formatter) };
+      if (v <= 650) return { value: 45, label: formatPercentileLabel(45, formatter) };
+      if (v <= 780) return { value: 50, label: formatPercentileLabel(50, formatter) };
+      if (v <= 950) return { value: 70, label: formatPercentileLabel(70, formatter) };
+      return { value: 90, label: formatPercentileLabel(90, formatter) };
     }
     case 'hitError': {
       const avgError = (analytics.gazeErrorAtHit + analytics.mouseErrorAtHit) / 2;
-      if (avgError <= 60) return { value: 15, label: formatPercentileLabel(15, formatter) };
-      if (avgError <= 90) return { value: 30, label: formatPercentileLabel(30, formatter) };
-      if (avgError <= 130) return { value: 55, label: formatPercentileLabel(55, formatter) };
-      if (avgError <= 170) return { value: 75, label: formatPercentileLabel(75, formatter) };
+      if (avgError <= 80) return { value: 20, label: formatPercentileLabel(20, formatter) };
+      if (avgError <= 120) return { value: 45, label: formatPercentileLabel(45, formatter) };
+      if (avgError <= 170) return { value: 65, label: formatPercentileLabel(65, formatter) };
+      if (avgError <= 230) return { value: 82, label: formatPercentileLabel(82, formatter) };
       return { value: 90, label: formatPercentileLabel(90, formatter) };
     }
     case 'sync': {
       const v = analytics.synchronization;
-      if (v <= 90) return { value: 15, label: formatPercentileLabel(15, formatter) };
-      if (v <= 140) return { value: 35, label: formatPercentileLabel(35, formatter) };
-      if (v <= 200) return { value: 60, label: formatPercentileLabel(60, formatter) };
-      return { value: 85, label: formatPercentileLabel(85, formatter) };
+      if (v <= 110) return { value: 18, label: formatPercentileLabel(18, formatter) };
+      if (v <= 150) return { value: 30, label: formatPercentileLabel(30, formatter) };
+      if (v <= 190) return { value: 40, label: formatPercentileLabel(40, formatter) };
+      if (v <= 230) return { value: 60, label: formatPercentileLabel(60, formatter) };
+      return { value: 80, label: formatPercentileLabel(80, formatter) };
     }
     default:
       return { value: 50, label: formatPercentileLabel(50, formatter) };
@@ -113,6 +118,11 @@ const ReportPage = () => {
     [language, t],
   );
 
+  const percentileTextColor = useMemo(
+    () => (pct: number) => (pct <= 35 ? '#66d9ff' : pct <= 70 ? '#f1c40f' : '#ff6b6b'),
+    [],
+  );
+
   const metricTooltips = useMemo(
     () => ({
       targets: t('results.tooltip.targets', 'Hits show decisiveness and tempo.'),
@@ -135,37 +145,37 @@ const ReportPage = () => {
         case 'targets': {
           const ratio = analytics.totalTargets > 0 ? analytics.targetsHit / analytics.totalTargets : 0;
           if (ratio >= 0.8) return { label: t('results.level.targets.top', 'High hit rate'), color: goodColor };
-          if (ratio >= 0.5) return { label: t('results.level.targets.mid', 'Average hit rate'), color: midColor };
+          if (ratio >= 0.7) return { label: t('results.level.targets.mid', 'Average hit rate'), color: midColor };
           return { label: t('results.level.targets.low', 'Needs hit rate improvement'), color: badColor };
         }
         case 'avgReaction': {
           const v = analytics.avgReactionTime;
-          if (v <= 300) return { label: t('results.level.reaction.top', 'Excellent reaction time'), color: goodColor };
-          if (v <= 600) return { label: t('results.level.reaction.mid', 'Average reaction time'), color: midColor };
+          if (v <= 450) return { label: t('results.level.reaction.top', 'Excellent reaction time'), color: goodColor };
+          if (v <= 900) return { label: t('results.level.reaction.mid', 'Average reaction time'), color: midColor };
           return { label: t('results.level.reaction.low', 'Needs reaction improvement'), color: badColor };
         }
         case 'gazeReaction': {
           const v = analytics.avgGazeReactionTime;
-          if (v <= 250) return { label: t('results.level.gaze.top', 'Fast gaze acquisition'), color: goodColor };
-          if (v <= 450) return { label: t('results.level.gaze.mid', 'Average gaze acquisition'), color: midColor };
+          if (v <= 320) return { label: t('results.level.gaze.top', 'Fast gaze acquisition'), color: goodColor };
+          if (v <= 520) return { label: t('results.level.gaze.mid', 'Average gaze acquisition'), color: midColor };
           return { label: t('results.level.gaze.low', 'Slow gaze acquisition'), color: badColor };
         }
         case 'gazeAimLatency': {
           const v = analytics.gazeAimLatency;
-          if (v <= 300) return { label: t('results.level.gazeAim.top', 'Short gaze-hand delay'), color: goodColor };
-          if (v <= 600) return { label: t('results.level.gazeAim.mid', 'Average gaze-hand delay'), color: midColor };
+          if (v <= 480) return { label: t('results.level.gazeAim.top', 'Short gaze-hand delay'), color: goodColor };
+          if (v <= 900) return { label: t('results.level.gazeAim.mid', 'Average gaze-hand delay'), color: midColor };
           return { label: t('results.level.gazeAim.low', 'Needs latency improvement'), color: badColor };
         }
         case 'hitError': {
           const avgError = (analytics.gazeErrorAtHit + analytics.mouseErrorAtHit) / 2;
           if (avgError <= 80) return { label: t('results.level.hitError.top', 'Excellent accuracy'), color: goodColor };
-          if (avgError <= 140) return { label: t('results.level.hitError.mid', 'Average accuracy'), color: midColor };
+          if (avgError <= 170) return { label: t('results.level.hitError.mid', 'Average accuracy'), color: midColor };
           return { label: t('results.level.hitError.low', 'Needs accuracy improvement'), color: badColor };
         }
         case 'sync': {
           const v = analytics.synchronization;
-          if (v <= 120) return { label: t('results.level.sync.top', 'Great gaze-mouse sync'), color: goodColor };
-          if (v <= 200) return { label: t('results.level.sync.mid', 'Average sync'), color: midColor };
+          if (v <= 150) return { label: t('results.level.sync.top', 'Great gaze-mouse sync'), color: goodColor };
+          if (v <= 230) return { label: t('results.level.sync.mid', 'Average sync'), color: midColor };
           return { label: t('results.level.sync.low', 'Needs sync improvement'), color: badColor };
         }
         default:
@@ -514,14 +524,24 @@ const ReportPage = () => {
             <div className="data-item">
               <span className="data-label">{t('report.data.reaction', '반응 속도')}</span>
               <span className="data-value">{report.metrics.reactionTime.toFixed(0)}ms</span>
-              <span className="data-percentile">(상위 {report.metrics.reactionTimePercentile}%)</span>
+              <span
+                className="data-percentile"
+                style={{ color: percentileTextColor(report.metrics.reactionTimePercentile) }}
+              >
+                (상위 {report.metrics.reactionTimePercentile}%)
+              </span>
             </div>
             {report.metrics.gazeReactionTime != null && (
               <div className="data-item">
                 <span className="data-label">{t('report.data.gazeReaction', '시선 반응')}</span>
                 <span className="data-value">{report.metrics.gazeReactionTime.toFixed(0)}ms</span>
                 {report.metrics.gazeReactionTimePercentile != null && (
-                  <span className="data-percentile">(상위 {report.metrics.gazeReactionTimePercentile}%)</span>
+                  <span
+                    className="data-percentile"
+                    style={{ color: percentileTextColor(report.metrics.gazeReactionTimePercentile) }}
+                  >
+                    (상위 {report.metrics.gazeReactionTimePercentile}%)
+                  </span>
                 )}
               </div>
             )}
@@ -530,14 +550,24 @@ const ReportPage = () => {
                 <span className="data-label">{t('report.data.gazeAimLatency', '시선-마우스 지연')}</span>
                 <span className="data-value">{report.metrics.gazeAimLatency.toFixed(0)}ms</span>
                 {report.metrics.gazeAimLatencyPercentile != null && (
-                  <span className="data-percentile">(상위 {report.metrics.gazeAimLatencyPercentile}%)</span>
+                  <span
+                    className="data-percentile"
+                    style={{ color: percentileTextColor(report.metrics.gazeAimLatencyPercentile) }}
+                  >
+                    (상위 {report.metrics.gazeAimLatencyPercentile}%)
+                  </span>
                 )}
               </div>
             )}
             <div className="data-item">
               <span className="data-label">{t('report.data.overlap', '시선-에임 일치도')}</span>
               <span className="data-value">{report.metrics.overlapScore.toFixed(1)}%</span>
-              <span className="data-percentile">(상위 {report.metrics.overlapScorePercentile}%)</span>
+              <span
+                className="data-percentile"
+                style={{ color: percentileTextColor(report.metrics.overlapScorePercentile) }}
+              >
+                (상위 {report.metrics.overlapScorePercentile}%)
+              </span>
             </div>
             <div className="data-item">
               <span className="data-label">{t('report.data.tracking', '트래킹 정확도')}</span>

--- a/frontend/src/pages/ResultsPage.css
+++ b/frontend/src/pages/ResultsPage.css
@@ -923,6 +923,10 @@
   align-items: center;
 }
 
+.delete-session-button {
+  margin-left: auto;
+}
+
 .upload-status {
   font-weight: 600;
   letter-spacing: 0.2px;
@@ -949,7 +953,8 @@
 /* Buttons */
 .download-button,
 .upload-button,
-.secondary-button {
+.secondary-button,
+.danger-button {
   padding: 0.75rem 1.4rem;
   border-radius: 10px;
   font-size: 1rem;
@@ -993,9 +998,22 @@
   transform: translateY(-2px);
 }
 
+.danger-button {
+  background: linear-gradient(135deg, #ff6b6b 0%, #c44569 100%);
+  color: #fff;
+  border: none;
+  box-shadow: 0 4px 15px rgba(255, 107, 107, 0.35);
+}
+
+.danger-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 26px rgba(255, 107, 107, 0.35);
+}
+
 .download-button:disabled,
 .upload-button:disabled,
-.secondary-button:disabled {
+.secondary-button:disabled,
+.danger-button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
   transform: none;

--- a/frontend/src/pages/ResultsPage.tsx
+++ b/frontend/src/pages/ResultsPage.tsx
@@ -44,49 +44,54 @@ const metricPercentile = (
   switch (key) {
     case 'targets': {
       const ratio = analytics.totalTargets > 0 ? analytics.targetsHit / analytics.totalTargets : 0;
-      if (ratio >= 0.9) return { value: 10, label: formatPercentileLabel(10, formatter) };
-      if (ratio >= 0.8) return { value: 20, label: formatPercentileLabel(20, formatter) };
-      if (ratio >= 0.65) return { value: 40, label: formatPercentileLabel(40, formatter) };
-      if (ratio >= 0.5) return { value: 60, label: formatPercentileLabel(60, formatter) };
+      if (ratio >= 0.95) return { value: 12, label: formatPercentileLabel(12, formatter) };
+      if (ratio >= 0.85) return { value: 28, label: formatPercentileLabel(28, formatter) };
+      if (ratio >= 0.7) return { value: 45, label: formatPercentileLabel(45, formatter) };
+      if (ratio >= 0.55) return { value: 65, label: formatPercentileLabel(65, formatter) };
       return { value: 85, label: formatPercentileLabel(85, formatter) };
     }
     case 'avgReaction': {
       const v = analytics.avgReactionTime;
-      if (v <= 200) return { value: 10, label: formatPercentileLabel(10, formatter) };
-      if (v <= 250) return { value: 25, label: formatPercentileLabel(25, formatter) };
-      if (v <= 300) return { value: 50, label: formatPercentileLabel(50, formatter) };
-      if (v <= 350) return { value: 70, label: formatPercentileLabel(70, formatter) };
-      return { value: 90, label: formatPercentileLabel(90, formatter) };
+      if (v <= 300) return { value: 10, label: formatPercentileLabel(10, formatter) };
+      if (v <= 450) return { value: 18, label: formatPercentileLabel(18, formatter) };
+      if (v <= 650) return { value: 26, label: formatPercentileLabel(26, formatter) };
+      if (v <= 820) return { value: 30, label: formatPercentileLabel(30, formatter) };
+      if (v <= 1100) return { value: 55, label: formatPercentileLabel(55, formatter) };
+      return { value: 85, label: formatPercentileLabel(85, formatter) };
     }
     case 'gazeReaction': {
       const v = analytics.avgGazeReactionTime;
-      if (v <= 200) return { value: 12, label: formatPercentileLabel(12, formatter) };
-      if (v <= 250) return { value: 25, label: formatPercentileLabel(25, formatter) };
-      if (v <= 350) return { value: 45, label: formatPercentileLabel(45, formatter) };
-      if (v <= 450) return { value: 65, label: formatPercentileLabel(65, formatter) };
-      return { value: 88, label: formatPercentileLabel(88, formatter) };
+      if (v <= 200) return { value: 10, label: formatPercentileLabel(10, formatter) };
+      if (v <= 280) return { value: 20, label: formatPercentileLabel(20, formatter) };
+      if (v <= 340) return { value: 35, label: formatPercentileLabel(35, formatter) };
+      if (v <= 420) return { value: 50, label: formatPercentileLabel(50, formatter) };
+      if (v <= 520) return { value: 72, label: formatPercentileLabel(72, formatter) };
+      return { value: 90, label: formatPercentileLabel(90, formatter) };
     }
     case 'gazeAimLatency': {
       const v = analytics.gazeAimLatency;
-      if (v <= 250) return { value: 15, label: formatPercentileLabel(15, formatter) };
-      if (v <= 400) return { value: 35, label: formatPercentileLabel(35, formatter) };
-      if (v <= 600) return { value: 60, label: formatPercentileLabel(60, formatter) };
-      return { value: 85, label: formatPercentileLabel(85, formatter) };
+      if (v <= 320) return { value: 18, label: formatPercentileLabel(18, formatter) };
+      if (v <= 480) return { value: 35, label: formatPercentileLabel(35, formatter) };
+      if (v <= 650) return { value: 45, label: formatPercentileLabel(45, formatter) };
+      if (v <= 780) return { value: 50, label: formatPercentileLabel(50, formatter) };
+      if (v <= 950) return { value: 70, label: formatPercentileLabel(70, formatter) };
+      return { value: 90, label: formatPercentileLabel(90, formatter) };
     }
     case 'hitError': {
       const avgError = (analytics.gazeErrorAtHit + analytics.mouseErrorAtHit) / 2;
-      if (avgError <= 60) return { value: 15, label: formatPercentileLabel(15, formatter) };
-      if (avgError <= 90) return { value: 30, label: formatPercentileLabel(30, formatter) };
-      if (avgError <= 130) return { value: 55, label: formatPercentileLabel(55, formatter) };
-      if (avgError <= 170) return { value: 75, label: formatPercentileLabel(75, formatter) };
+      if (avgError <= 80) return { value: 20, label: formatPercentileLabel(20, formatter) };
+      if (avgError <= 120) return { value: 45, label: formatPercentileLabel(45, formatter) };
+      if (avgError <= 170) return { value: 65, label: formatPercentileLabel(65, formatter) };
+      if (avgError <= 230) return { value: 82, label: formatPercentileLabel(82, formatter) };
       return { value: 90, label: formatPercentileLabel(90, formatter) };
     }
     case 'sync': {
       const v = analytics.synchronization;
-      if (v <= 90) return { value: 15, label: formatPercentileLabel(15, formatter) };
-      if (v <= 140) return { value: 35, label: formatPercentileLabel(35, formatter) };
-      if (v <= 200) return { value: 60, label: formatPercentileLabel(60, formatter) };
-      return { value: 85, label: formatPercentileLabel(85, formatter) };
+      if (v <= 110) return { value: 18, label: formatPercentileLabel(18, formatter) };
+      if (v <= 150) return { value: 30, label: formatPercentileLabel(30, formatter) };
+      if (v <= 190) return { value: 40, label: formatPercentileLabel(40, formatter) };
+      if (v <= 230) return { value: 60, label: formatPercentileLabel(60, formatter) };
+      return { value: 80, label: formatPercentileLabel(80, formatter) };
     }
     default:
       return { value: 50, label: formatPercentileLabel(50, formatter) };
@@ -453,37 +458,37 @@ const ResultsPage = () => {
         case 'targets': {
           const ratio = analytics.totalTargets > 0 ? analytics.targetsHit / analytics.totalTargets : 0;
           if (ratio >= 0.8) return { label: t('results.level.targets.top', 'High hit rate'), color: goodColor };
-          if (ratio >= 0.5) return { label: t('results.level.targets.mid', 'Average hit rate'), color: midColor };
+          if (ratio >= 0.7) return { label: t('results.level.targets.mid', 'Average hit rate'), color: midColor };
           return { label: t('results.level.targets.low', 'Needs hit rate improvement'), color: badColor };
         }
         case 'avgReaction': {
           const v = analytics.avgReactionTime;
-          if (v <= 300) return { label: t('results.level.reaction.top', 'Excellent reaction time'), color: goodColor };
-          if (v <= 600) return { label: t('results.level.reaction.mid', 'Average reaction time'), color: midColor };
+          if (v <= 450) return { label: t('results.level.reaction.top', 'Excellent reaction time'), color: goodColor };
+          if (v <= 900) return { label: t('results.level.reaction.mid', 'Average reaction time'), color: midColor };
           return { label: t('results.level.reaction.low', 'Needs reaction improvement'), color: badColor };
         }
         case 'gazeReaction': {
           const v = analytics.avgGazeReactionTime;
-          if (v <= 250) return { label: t('results.level.gaze.top', 'Fast gaze acquisition'), color: goodColor };
-          if (v <= 450) return { label: t('results.level.gaze.mid', 'Average gaze acquisition'), color: midColor };
+          if (v <= 320) return { label: t('results.level.gaze.top', 'Fast gaze acquisition'), color: goodColor };
+          if (v <= 520) return { label: t('results.level.gaze.mid', 'Average gaze acquisition'), color: midColor };
           return { label: t('results.level.gaze.low', 'Slow gaze acquisition'), color: badColor };
         }
         case 'gazeAimLatency': {
           const v = analytics.gazeAimLatency;
-          if (v <= 300) return { label: t('results.level.gazeAim.top', 'Short gaze-hand delay'), color: goodColor };
-          if (v <= 600) return { label: t('results.level.gazeAim.mid', 'Average gaze-hand delay'), color: midColor };
+          if (v <= 480) return { label: t('results.level.gazeAim.top', 'Short gaze-hand delay'), color: goodColor };
+          if (v <= 900) return { label: t('results.level.gazeAim.mid', 'Average gaze-hand delay'), color: midColor };
           return { label: t('results.level.gazeAim.low', 'Needs latency improvement'), color: badColor };
         }
         case 'hitError': {
           const avgError = (analytics.gazeErrorAtHit + analytics.mouseErrorAtHit) / 2;
           if (avgError <= 80) return { label: t('results.level.hitError.top', 'Excellent accuracy'), color: goodColor };
-          if (avgError <= 140) return { label: t('results.level.hitError.mid', 'Average accuracy'), color: midColor };
+          if (avgError <= 170) return { label: t('results.level.hitError.mid', 'Average accuracy'), color: midColor };
           return { label: t('results.level.hitError.low', 'Needs accuracy improvement'), color: badColor };
         }
         case 'sync': {
           const v = analytics.synchronization;
-          if (v <= 120) return { label: t('results.level.sync.top', 'Great gaze-mouse sync'), color: goodColor };
-          if (v <= 200) return { label: t('results.level.sync.mid', 'Average sync'), color: midColor };
+          if (v <= 150) return { label: t('results.level.sync.top', 'Great gaze-mouse sync'), color: goodColor };
+          if (v <= 230) return { label: t('results.level.sync.mid', 'Average sync'), color: midColor };
           return { label: t('results.level.sync.low', 'Needs sync improvement'), color: badColor };
         }
         default:

--- a/frontend/src/pages/ResultsPage.tsx
+++ b/frontend/src/pages/ResultsPage.tsx
@@ -14,8 +14,8 @@ import { exportSessionData, type CsvUploadResult } from '../utils/sessionExport'
 import { useWebgazer } from '../hooks/tracking/useWebgazer';
 import { useAuth } from '../state/authContext';
 import { useTranslation } from '../state/languageContext';
-import { persistLatestSession } from '../utils/resultsStorage';
-import { saveSessionForUser } from '../utils/remoteSessions';
+import { persistLatestSession, LATEST_SESSION_STORAGE_KEY } from '../utils/resultsStorage';
+import { deleteSessionForUser, saveSessionForUser } from '../utils/remoteSessions';
 // Analytics 인터페이스와 함수를 utils에서 import (ResultsPage 내의 중복 정의 제거)
 import { calculatePerformanceAnalytics, generateErrorTimeSeries, PerformanceAnalytics } from '../utils/analytics';
 import { predictScore } from '../services/predictionService';
@@ -373,7 +373,8 @@ const ResultsPage = () => {
     consentAccepted,
     calibrationResult,
     setActiveSessionId,
-    isAnonymousSession
+    removeSession,
+    isAnonymousSession,
   } = useTrackingSession();
   
   const { stopSession } = useWebgazer();
@@ -404,6 +405,7 @@ const ResultsPage = () => {
 
   const [missingRawData, setMissingRawData] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const [lastUploadResult, setLastUploadResult] = useState<CsvUploadResult | null>(null);
   const [autoUploadAttemptedFor, setAutoUploadAttemptedFor] = useState<string | null>(null);
   // 초기화 시점에 바로 sessionStorage를 확인하여 상태를 설정합니다. - csv 수동 업로드 버튼 재활성화 방지
@@ -931,6 +933,43 @@ const ResultsPage = () => {
     persistUploadStatus(sessionData?.id, status);
   }, [handleExport, sessionData?.id]);
 
+  const handleDeleteSession = useCallback(async () => {
+    if (!sessionData) return;
+
+    const confirmed = window.confirm(
+      t('results.delete.confirm', 'Delete this session data permanently? This cannot be undone.'),
+    );
+    if (!confirmed) return;
+
+    setIsDeleting(true);
+    try {
+      if (user?.uid) {
+        await deleteSessionForUser(user.uid, sessionData.id);
+      }
+      removeSession(sessionData.id);
+      if (typeof window !== 'undefined') {
+        window.sessionStorage.removeItem(LATEST_SESSION_STORAGE_KEY);
+      }
+      showToast(t('results.toast.deleteSuccess', 'Session data deleted.'), 'success');
+      navigate('/sessions');
+    } catch (error) {
+      console.error('Failed to delete session', error);
+      showToast(
+        t('results.toast.deleteError', 'Failed to delete the session. Please try again shortly.'),
+        'error',
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [
+    navigate,
+    removeSession,
+    sessionData,
+    showToast,
+    t,
+    user?.uid,
+  ]);
+
   const handleOpenDetailed = (focusMetric?: string) => {
     if (sessionData) {
       persistLatestSession(sessionData, calibrationResult);
@@ -1435,7 +1474,6 @@ const ResultsPage = () => {
               {t('results.action.trainAgain')}
             </button>
             
-
             <button 
               className="secondary-button" 
               onClick={() => navigate('/report')}
@@ -1443,6 +1481,15 @@ const ResultsPage = () => {
             >
               <Sparkles size={20} />
               {t('report.actions.generate', 'Generate report')}
+            </button>
+            <button
+              className="danger-button delete-session-button"
+              onClick={handleDeleteSession}
+              disabled={isDeleting}
+            >
+              {isDeleting
+                ? t('results.data.deleting', 'Deleting…')
+                : t('results.data.delete', 'Delete Session')}
             </button>
           </div>
         </section>

--- a/frontend/src/pages/SessionsHistoryPage.css
+++ b/frontend/src/pages/SessionsHistoryPage.css
@@ -420,7 +420,7 @@
 
 .table-actions-group {
   display: grid;
-  grid-template-columns: repeat(2, minmax(95px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(95px, 1fr));
   gap: 0.5rem;
   margin: 0 auto;
   min-width: 200px;
@@ -468,6 +468,50 @@
 .report-button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.delete-button {
+  padding: 0.45rem 0.9rem;
+  background: rgba(255, 99, 132, 0.12);
+  border: 1px solid rgba(255, 99, 132, 0.5);
+  color: #ffb3c0;
+  border-radius: 10px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.delete-button:hover:enabled {
+  background: rgba(255, 99, 132, 0.25);
+  border-color: rgba(255, 99, 132, 0.8);
+  transform: translateY(-2px);
+}
+
+.delete-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.delete-status {
+  margin-top: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  font-weight: 700;
+  color: #f7f7ff;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.delete-status.success {
+  border-color: rgba(78, 205, 196, 0.6);
+  color: #a9f0e9;
+}
+
+.delete-status.error {
+  border-color: rgba(255, 99, 132, 0.6);
+  color: #ffb3c0;
 }
 
 /* Empty State */
@@ -557,7 +601,8 @@
   }
 
   .view-button,
-  .report-button {
+  .report-button,
+  .delete-button {
     padding: 0.35rem 0.7rem;
     font-size: 0.8rem;
     width: 100%;

--- a/frontend/src/pages/SessionsHistoryPage.tsx
+++ b/frontend/src/pages/SessionsHistoryPage.tsx
@@ -8,6 +8,7 @@ import { getUserReports } from '../services/reportService';
 import { calculatePerformanceAnalytics } from '../utils/analytics';
 import { Line } from 'react-chartjs-2';
 import { AlertTriangle, Lightbulb } from 'lucide-react';
+import { deleteSessionForUser } from '../utils/remoteSessions';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -39,7 +40,7 @@ type TrendPeriod = '7days' | '30days';
 const SessionsHistoryPage = () => {
   const navigate = useNavigate();
   const { t, language } = useTranslation();
-  const { recentSessions, setActiveSessionId } = useTrackingSession();
+  const { recentSessions, setActiveSessionId, removeSession } = useTrackingSession();
   const { user } = useAuth();
 
   const [sortField, setSortField] = useState<SortField>('date');
@@ -47,6 +48,8 @@ const SessionsHistoryPage = () => {
   const [trendPeriod, setTrendPeriod] = useState<TrendPeriod>('7days');
   const [sessionReportMap, setSessionReportMap] = useState<Record<string, string>>({});
   const [isLoadingReports, setIsLoadingReports] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deleteStatus, setDeleteStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
 
   // Load reports on mount
   useEffect(() => {
@@ -263,6 +266,38 @@ const SessionsHistoryPage = () => {
     navigate('/report', { state: { sessionId } });
   };
 
+  const handleDeleteSession = async (sessionId: string) => {
+    const confirmed = window.confirm(
+      t(
+        'sessions.delete.confirm',
+        'Delete this session from your history? This action cannot be undone.',
+      ),
+    );
+    if (!confirmed) return;
+
+    setDeletingId(sessionId);
+    setDeleteStatus(null);
+
+    try {
+      if (user?.uid) {
+        await deleteSessionForUser(user.uid, sessionId);
+      }
+      removeSession(sessionId);
+      setDeleteStatus({
+        type: 'success',
+        message: t('sessions.delete.success', 'Session removed from your history.'),
+      });
+    } catch (error) {
+      console.error('Failed to delete session', error);
+      setDeleteStatus({
+        type: 'error',
+        message: t('sessions.delete.error', 'Failed to delete the session. Please try again.'),
+      });
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
   const formatDate = (date: string) => {
     const dateObj = new Date(date);
     const locale = language === 'ko' ? 'ko-KR' : 'en-US';
@@ -468,6 +503,11 @@ const SessionsHistoryPage = () => {
             </span>
           </div>
         </div>
+        {deleteStatus && (
+          <div className={`delete-status ${deleteStatus.type}`}>
+            {deleteStatus.message}
+          </div>
+        )}
 
         {displaySessions.length === 0 ? (
           <div className="empty-state">
@@ -569,6 +609,15 @@ const SessionsHistoryPage = () => {
                           {sessionReportMap[session.id]
                             ? t('sessions.table.report.viewExisting', 'View Report')
                             : t('sessions.table.report.create', 'Create Report')}
+                        </button>
+                        <button
+                          className="delete-button"
+                          onClick={() => handleDeleteSession(session.id)}
+                          disabled={deletingId === session.id}
+                        >
+                          {deletingId === session.id
+                            ? t('sessions.table.deleting', 'Deleting...')
+                            : t('sessions.table.delete', 'Delete')}
                         </button>
                       </div>
                     </td>

--- a/frontend/src/services/reportService.ts
+++ b/frontend/src/services/reportService.ts
@@ -56,42 +56,45 @@ const calculatePercentiles = (metrics: {
   gazeAimLatencyPercentile: number | null;
 } => {
   // Reaction time percentiles (lower is better)
-  // Elite: <200ms, Good: 200-250ms, Average: 250-300ms, Below avg: >300ms
+  // Calibrated so ~800ms sits around Top 30%
   let reactionTimePercentile = 50;
-  if (metrics.reactionTime < 200) reactionTimePercentile = 10;
-  else if (metrics.reactionTime < 250) reactionTimePercentile = 25;
-  else if (metrics.reactionTime < 300) reactionTimePercentile = 50;
-  else if (metrics.reactionTime < 350) reactionTimePercentile = 70;
+  if (metrics.reactionTime <= 300) reactionTimePercentile = 10;
+  else if (metrics.reactionTime <= 450) reactionTimePercentile = 18;
+  else if (metrics.reactionTime <= 650) reactionTimePercentile = 26;
+  else if (metrics.reactionTime <= 820) reactionTimePercentile = 30;
+  else if (metrics.reactionTime <= 1100) reactionTimePercentile = 55;
   else reactionTimePercentile = 85;
 
   // Overlap score percentiles (higher is better)
-  // Elite: >85%, Good: 75-85%, Average: 60-75%, Below avg: <60%
   let overlapScorePercentile = 50;
-  if (metrics.overlapScore > 85) overlapScorePercentile = 10;
-  else if (metrics.overlapScore > 75) overlapScorePercentile = 20;
-  else if (metrics.overlapScore > 65) overlapScorePercentile = 40;
-  else if (metrics.overlapScore > 55) overlapScorePercentile = 60;
-  else overlapScorePercentile = 70;
+  if (metrics.overlapScore > 90) overlapScorePercentile = 12;
+  else if (metrics.overlapScore > 82) overlapScorePercentile = 28;
+  else if (metrics.overlapScore > 72) overlapScorePercentile = 45;
+  else if (metrics.overlapScore > 60) overlapScorePercentile = 65;
+  else overlapScorePercentile = 85;
 
   // Gaze reaction (lower is better)
   let gazeReactionTimePercentile: number | null = null;
   if (metrics.gazeReactionTime != null) {
     const v = metrics.gazeReactionTime;
-    if (v <= 200) gazeReactionTimePercentile = 12;
-    else if (v <= 250) gazeReactionTimePercentile = 25;
-    else if (v <= 350) gazeReactionTimePercentile = 45;
-    else if (v <= 450) gazeReactionTimePercentile = 65;
-    else gazeReactionTimePercentile = 88;
+    if (v <= 200) gazeReactionTimePercentile = 10;
+    else if (v <= 280) gazeReactionTimePercentile = 20;
+    else if (v <= 340) gazeReactionTimePercentile = 35;
+    else if (v <= 420) gazeReactionTimePercentile = 50;
+    else if (v <= 520) gazeReactionTimePercentile = 72;
+    else gazeReactionTimePercentile = 90;
   }
 
   // Gaze-aim latency (lower is better)
   let gazeAimLatencyPercentile: number | null = null;
   if (metrics.gazeAimLatency != null) {
     const v = metrics.gazeAimLatency;
-    if (v <= 250) gazeAimLatencyPercentile = 15;
-    else if (v <= 400) gazeAimLatencyPercentile = 35;
-    else if (v <= 600) gazeAimLatencyPercentile = 60;
-    else gazeAimLatencyPercentile = 85;
+    if (v <= 320) gazeAimLatencyPercentile = 18;
+    else if (v <= 480) gazeAimLatencyPercentile = 35;
+    else if (v <= 650) gazeAimLatencyPercentile = 45;
+    else if (v <= 780) gazeAimLatencyPercentile = 50;
+    else if (v <= 950) gazeAimLatencyPercentile = 70;
+    else gazeAimLatencyPercentile = 90;
   }
 
   return { reactionTimePercentile, overlapScorePercentile, gazeReactionTimePercentile, gazeAimLatencyPercentile };

--- a/frontend/src/state/trackingSessionContext.tsx
+++ b/frontend/src/state/trackingSessionContext.tsx
@@ -72,6 +72,7 @@ export interface TrackingSessionContextValue extends TrackingSessionState {
   addSession: (session: TrainingSessionSummary) => void;
   hydrateSessions: (sessions: TrainingSessionSummary[]) => void;
   setActiveSessionId: (sessionId: string | null) => void;
+  removeSession: (sessionId: string) => void;
   clearRecentSessions: () => void;
   activeSession: TrainingSessionSummary | null;
   setAnonymousSession: (isAnonymous: boolean) => void;
@@ -247,6 +248,23 @@ export const TrackingSessionProvider = ({ children }: { children: ReactNode }) =
     }));
   };
 
+  const removeSession = (sessionId: string) => {
+    setState(prev => {
+      const filteredSessions = prev.recentSessions.filter(session => session.id !== sessionId);
+      const hasActive = filteredSessions.some(session => session.id === prev.activeSessionId);
+      const nextActiveId = hasActive
+        ? prev.activeSessionId
+        : filteredSessions[0]?.id ?? null;
+
+      return {
+        ...prev,
+        recentSessions: filteredSessions,
+        lastSession: filteredSessions[0] ?? null,
+        activeSessionId: nextActiveId,
+      };
+    });
+  };
+
   const setAnonymousSession = (isAnonymous: boolean) => {
     setState(prev => ({
       ...prev,
@@ -283,6 +301,7 @@ export const TrackingSessionProvider = ({ children }: { children: ReactNode }) =
     addSession,
     hydrateSessions,
     setActiveSessionId,
+    removeSession,
     clearRecentSessions,
     activeSession,
     setAnonymousSession,

--- a/frontend/src/tests/mocks/trackingSession.ts
+++ b/frontend/src/tests/mocks/trackingSession.ts
@@ -25,6 +25,7 @@ export const createTrackingSessionValue = (
   addSession: vi.fn(),
   hydrateSessions: vi.fn(),
   setActiveSessionId: vi.fn(),
+  removeSession: vi.fn(),
   clearRecentSessions: vi.fn(),
   activeSession: null,
   setAnonymousSession: vi.fn(),

--- a/frontend/src/utils/remoteSessions.ts
+++ b/frontend/src/utils/remoteSessions.ts
@@ -1,6 +1,7 @@
 import {
   collection,
   doc,
+  deleteDoc,
   getDocs,
   orderBy,
   query,
@@ -171,6 +172,13 @@ export const fetchSessionsForUser = async (uid: string): Promise<StoredSessionRe
       leaderboardLabel: record.leaderboardLabel ?? null,
     }));
 
+};
+
+export const deleteSessionForUser = async (uid: string, sessionId: string): Promise<void> => {
+  const sessionRef = doc(db, 'users', uid, 'sessions', sessionId);
+  const leaderboardRef = doc(db, 'leaderboardEntries', `${uid}-${sessionId}`);
+
+  await Promise.allSettled([deleteDoc(sessionRef), deleteDoc(leaderboardRef)]);
 };
 
 export const saveSessionForUser = async (


### PR DESCRIPTION
Added Firestore cleanup helper and context support for per-session removal so state/local storage stay in sync (frontend/src/utils/remoteSessions.ts, frontend/src/state/trackingSessionContext.tsx).
Session History now includes a Delete action per row with confirm, loading state, and localized feedback; layout and styles updated to fit the third action (frontend/src/pages/SessionsHistoryPage.tsx, frontend/src/pages/SessionsHistoryPage.css, frontend/src/constants/translations.ts).
Results page “Session Data” section now has a red delete button that removes the session (and leaderboard entry), clears cached session data, shows a toast, and routes to the sessions list (frontend/src/pages/ResultsPage.tsx, frontend/src/pages/ResultsPage.css, frontend/src/constants/translations.ts).